### PR TITLE
Updating worker version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-git+https://git@github.com/fabric8-analytics/fabric8-analytics-worker.git@ca7d91f#egg=f8a_worker
+git+https://git@github.com/fabric8-analytics/fabric8-analytics-worker.git@58d3025#egg=f8a_worker
 git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@3bca34e
 git+https://git@github.com/fabric8-analytics/fabric8-analytics-version-comparator.git#egg=f8a_version_comparator
+


### PR DESCRIPTION
# Description

Currently refresh job uses different version of worker than API server and backbone.
To fix it refresh job worker version which is used in API server is used for now. Later I will be pointing it to the latest worker.
With old version we are facing some issue in GitDB library as its been upgraded.